### PR TITLE
URI unescape fix for some youtube pages

### DIFF
--- a/lib/FlashVideo/Site/Youtube.pm
+++ b/lib/FlashVideo/Site/Youtube.pm
@@ -48,8 +48,9 @@ sub find_video {
   # If the page contains fmt_url_map, then process this. With this, we
   # don't require the 't' parameter.
   if ($browser->content =~ /["']fmt_url_map["']:\s{0,3}(["'][^"']+["'])/) {
-    debug "Using fmt_url_map method from page ($1)";
-    return $self->download_fmt_map($prefs, $browser, $title, {}, @{from_json $1});
+    my $fmt_map = uri_unescape($1);
+    debug "Using fmt_url_map method from page ($fmt_map)";
+    return $self->download_fmt_map($prefs, $browser, $title, {}, @{from_json $fmt_map});
   }
 
   my $video_id;


### PR DESCRIPTION
Simple URI unescaping fix; as I noticed the "themed" version of this youtube channel page did not work but the plain youtube page did.

http://www.youtube.com/user/carpoolUK#p/u/3/kAg0MdfzqSI

[this is my first time using github; I hope I am following the correct procedure to submit this patch]
