### PR TITLE
An escape error has occured when the page of Youtube contains utf8 string

### DIFF
--- a/lib/FlashVideo/Site/Youtube.pm
+++ b/lib/FlashVideo/Site/Youtube.pm
@@ -391,7 +391,7 @@ sub get_youtube_video_info {
       "http://www.youtube.com/get_video_info?&video_id=%s&el=$el&ps=default&eurl=%s&hl=en_US&t=%s";
 
     my $video_info_url = sprintf $video_info_url_template,
-      uri_escape($video_id), uri_escape($url), uri_escape($t);
+      uri_escape($video_id), uri_escape($url), uri_escape_utf8($t);
 
     debug "get_youtube_video_info: $video_info_url";
 


### PR DESCRIPTION
An escape error has occured when the page of Youtube contains utf8 strings.

% ./get_flash_videos 'http://www.youtube.com/watch?v=5zaNJWKWx2k'
Downloading http://www.youtube.com/watch?v=5zaNJWKWx2k
Using method 'youtube' for http://www.youtube.com/watch?v=5zaNJWKWx2k
Error: Can't escape \x{6771}, try uri_escape_utf8() instead at /Users/youhei/src/get-flash-videos/lib/FlashVideo/Site/Youtube.pm line 393

Couldn't extract Flash movie URL. This site may need specific support adding,
or fixing.

Please confirm the site is using Flash video and if you have Flash available
check that the URL really works(!).

Check for updates by running: ./get_flash_videos --update

If the latest version does not support this please open a bug (or
contribute a patch!) at http://code.google.com/p/get-flash-videos/
make sure you include the output with --debug enabled.
Couldn't download any videos.
