### PR TITLE
Grab Youtube Title from Video Info

### DIFF
--- a/lib/FlashVideo/Site/Youtube.pm
+++ b/lib/FlashVideo/Site/Youtube.pm
@@ -135,6 +135,9 @@ sub find_video {
       return $self->download_fmt_map($prefs, $browser, $title, \%info, $info{fmt_url_map});
     } elsif($info{url_encoded_fmt_stream_map}) {
       debug "Using url_encoded_fmt_stream_map method from info";
+      if ($info{title}) {
+        $title=$info{title};
+      }
       return $self->download_url_encoded_fmt_stream_map($prefs, $browser, $title, \%info, $info{url_encoded_fmt_stream_map});
     }
   }


### PR DESCRIPTION
I was getting videos downloading as "video[0-9]*.mp4"
It was unfortunate.

I'm somewhat concerned, though, because this fix looked really
simple, and I'm concerned that I've done something foolish.
