### PR TITLE
Make the Tudou SWF regex more liberal - it can change

### DIFF
--- a/lib/FlashVideo/Site/Tudou.pm
+++ b/lib/FlashVideo/Site/Tudou.pm
@@ -53,7 +53,7 @@ sub find_video {
 
     # Video ID is in the URL if we are either at the redirected URL
     # or at the embedded link that sends the redirect
-    ( $videoID ) = ( $embed_url =~ m`tudou.com/player/outside/player_outside.swf\?iid=(\d+)` );
+    ( $videoID ) = ( $embed_url =~ m`\.swf\?iid=(\d+)` );
   }
 
   die "Couldn't extract video ID, we are out probably out of date" unless $videoID;


### PR DESCRIPTION
Fix as detailed at https://code.google.com/p/get-flash-videos/issues/detail?id=163

The Flash player path that is searched for on line 58 of Tudou.pm has changed. This commit has a very loose regex to get the Flash player, as it appears to be volatile. An explicit regex for this particular player would be:

( $videoID ) = ( $embed_url =~ m`http://js\.tudouui\.com/bin/player2/olc_6\.swf\?iid=(\d+)` );
