### PR TITLE
fix compile error in generated combined code

### DIFF
--- a/utils/combine-perl.pl
+++ b/utils/combine-perl.pl
@@ -79,6 +79,7 @@ sub process_file {
       } else {
         if(/^\s*use [^ ;(]+((?: |\()[^;]*)?;/) {
           my $params = defined $1 ? $1 : "";
+          $params =~ s/^(\s*[0-9.]+)\s*\(\s*\)\s*$/\1/;
           if($params !~ /^\s*\(\s*\)\s*$/) {
             my @items = eval $params;
             $output .= "BEGIN { $module->import($params); } # (added by $0)\n";


### PR DESCRIPTION
util/combine_perl.pl for use module VERSION (); generates import (VERSION ()) which does not compile removing the () does compile, and matches other cases where use ... VERSION; occurs in some imported modules.
