### PR TITLE
Bad RegEx Looking for Video ID

### DIFF
--- a/lib/FlashVideo/Site/Youtube.pm
+++ b/lib/FlashVideo/Site/Youtube.pm
@@ -67,7 +67,7 @@ sub find_video {
 
   my $video_id;
   if ($browser->content =~ /(?:var pageVideoId =|(?:CFG_)?VIDEO_ID'?\s*:)\s*'(.+?)'/
-      || $browser->content =~ /video_id=([^&]+)/
+      || $browser->content =~ /[&?]video_id=([^&"]+)/
       || $embed_url =~ /v=([^&]+)/
       || $browser->content =~ /&amp;video_id=([^&]+)&amp;/) {
     $video_id = $1;


### PR DESCRIPTION
There was a "video_id=" in http://www.youtube.com/watch?v=9bZkp7q19f0,
but it didn't have an '&' after it as the regex was expecting, so it
overran a and consumed a substantial part of the page.

So, I've changed it.
I don't know if it's not matching now, so it's going to the more
effective fall-through, or it's more correct now, but either way it's
working.
