### PR TITLE
Get restricted embedded Vimeo videos

### DIFF
--- a/lib/FlashVideo/Site/Vimeo.pm
+++ b/lib/FlashVideo/Site/Vimeo.pm
@@ -39,6 +39,9 @@ sub find_video {
             "&codecs=H264,VP8,VP6&type=moogaloop_local&embed_location=";
   my $filename = title_to_filename($title, "flv");
 
+  $browser->get($url, Referer => $embed_url);
+  $url = $browser->response->header('Location');
+
   $browser->allow_redirects;
 
   return $url, $filename;


### PR DESCRIPTION
Vimeo Plus allows creators to restrict embedding by domain. This is
enforced by checking the Referer header.

See http://skillsmatter.com/podcast/home/high-performance-concurrency for an example
