### PR TITLE
Fix bogus type check to look for the correct type

### DIFF
--- a/get_flash_videos
+++ b/get_flash_videos
@@ -341,7 +341,7 @@ sub download {
   }
 
   my $suggested_filename = $suggested_fnames[-1];
-  if (ref($actual_url) eq 'ARRAY') {
+  if (ref($actual_url) eq 'HASH') {
       $suggested_filename ||= $actual_url->{flv};
   }
 


### PR DESCRIPTION
I'm relatively sure that this is what was meant.

Doesn't fix any video downloaders, but gets me from a bogus error to a real
error on Mtvnservices. (Why is Mtvnservices always busted?) :c
