### PR TITLE
Update Wat.pm

### DIFF
--- a/lib/FlashVideo/Site/Wat.pm
+++ b/lib/FlashVideo/Site/Wat.pm
@@ -13,9 +13,9 @@ die "Must have Digest::MD5 for this download\n"
 
 sub token {
   my $url = shift;
-  my $hexdate = sprintf("%x",time());
-  # fill up triling zeroes
-  $hexdate .= "0" x (length($hexdate) - 8);
+  my $hexdate = $browser->get("http://www.wat.tv/servertime");
+  my @timestamp=split('|',$hexdate);
+  $hexdate=sprintf("%x",shift(@timestamp));
   my $key = "9b673b13fa4682ed14c3cfa5af5310274b514c4133e9b3a81e6e3aba00912564";
   return Digest::MD5::md5_hex($key . $url . $hexdate)."/".$hexdate;
 }


### PR DESCRIPTION
I have been analysing the wat.tv flashplayer and found out, that it takes the time from the http://www.wat.tv/servertime address. The first value is the time in unixtime. This one just needs to be converted to hex and that's it. My greasemonkey script for direct playing the video with a video plugin is working with that.
