### PR TITLE
If plugin fails to open display error messages issue 403

### DIFF
--- a/get_flash_videos
+++ b/get_flash_videos
@@ -695,8 +695,11 @@ sub plugin_loader {
 
     debug "Trying to open plugin $plugin_dir/$plugin_name";
 
-    if (open my $plugin_fh, '<', "$plugin_dir/$plugin_name") {
-      return $plugin_fh; # Perl then reads the plugin from the FH
+    if (-s "$plugin_dir/$plugin_name") {
+      if (open my $plugin_fh, '<', "$plugin_dir/$plugin_name") {
+        return $plugin_fh; # Perl then reads the plugin from the FH
+      }
+      info "Failed to open plugin $plugin_dir/$plugin_name $!";
     }
   }
 


### PR DESCRIPTION
One possible cause for issue 403, make it appent what's wrong.
