### PR TITLE
Fix a 404 error on some newer Pinkbike videos

### DIFF
--- a/lib/FlashVideo/Site/Pinkbike.pm
+++ b/lib/FlashVideo/Site/Pinkbike.pm
@@ -17,10 +17,22 @@ sub find_video {
 
   die "Unable to extract url" unless $video_id;
 
-  my $url = "http://lv1.pinkbike.org/vf/" . (int($video_id / 10000)) . "/pbvid-" . $video_id . ".flv";
-  debug("Video URL: " . $url);
+  my $rel_url = ".pinkbike.org/vf/" . (int($video_id / 10000)) . "/pbvid-" . $video_id;
+  my @urls;
+  push @urls, "http://gv1" . $rel_url . ".mp4";
+  push @urls, "http://lv1" . $rel_url . ".flv";
 
-  return $url, $filename;
+  foreach my $url (@urls) {
+      debug("Checking if URL exists:" . $url);
+      if ($browser->head($url)->is_success) {
+          debug("Video URL: " . $url);
+          return $url, $filename;
+      }
+  }
+
+  die "No existing url found …";
+
+
 }
 
 1;

--- a/t/urls
+++ b/t/urls
@@ -307,3 +307,4 @@ http://www.tv4play.se/barn/postis_per?title=postis_per_del_10&videoid=823994
 
 # Pinkbike
 http://www.pinkbike.com/video/4263/
+http://www.pinkbike.com/video/306729/


### PR DESCRIPTION
Some new videos use a different url template, this patch issues a HEAD 
request on each url template and returns the one found.
