### PR TITLE
Mechanize: Spit out 'X-Died' error, if present.

### DIFF
--- a/lib/FlashVideo/Mechanize.pm
+++ b/lib/FlashVideo/Mechanize.pm
@@ -78,6 +78,8 @@ sub get {
     print STDERR "<- $text\n";
   }
 
+  print STDERR $self->response->header("X-Died")."\n" if(defined $self->response->header("X-Died") && ! $App::get_flash_videos::opt{quiet} );
+
   return $r;
 }
 


### PR DESCRIPTION
```
This exposes failures caused by "twitter:card" meta infestation, and probably other things too.
```

Test url: http://www.bbc.co.uk/news/uk-politics-16509892
Distributions affected by example issue: optware, debian squeeze, html::parser < 3.71
To fix example issue: upgrade to HTML-Parser-3.71 or https://github.com/atomicdryad/get-flash-videos/tree/twitter_meta_tag_fix
