### PR TITLE
Prevent self-induced page truncation with twitter headers and old HTML::Parser

### DIFF
--- a/lib/FlashVideo/Mechanize.pm
+++ b/lib/FlashVideo/Mechanize.pm
@@ -10,7 +10,7 @@ use base "WWW::Mechanize";
 
 sub new {
   my $class = shift;
-  my $browser = $class->SUPER::new(autocheck => 0);
+  my $browser = $class->SUPER::new(autocheck => 0, parse_head => 0);
   $browser->agent_alias("Windows Mozilla");
 
   my $proxy = $App::get_flash_videos::opt{proxy};


### PR DESCRIPTION
Issue: Any page with 'twitter:card' meta headers will be truncated. get_flash_videos will
    complain that it can't find a video, while neglecting to mention this.
Test url: http://www.bbc.co.uk/news/uk-politics-16509892
Affected distributions: Optware, Debian Squeeze, and likely alot of embedded linux devices
    where fetching the latest from cpan is not possible locally, and requires a dev environment
    with a cross-compiler and workarounds.
Upstream culprit: ancient HTML::Parser library. 3.71 fixes this.
Caveat: This disables the standard LWP behavior of sticking meta headers into the http headers
    hash. From what I can tell, this should have no adverse consequences ('meta name="location"' is invalid.)

See also:
https://github.com/libwww-perl/http-message/issues/3
https://rt.cpan.org/Public/Bug/Display.html?id=85119
