### PR TITLE
fix youtube plugin verify_age function to handle 301 responses

### DIFF
--- a/lib/FlashVideo/Site/Youtube.pm
+++ b/lib/FlashVideo/Site/Youtube.pm
@@ -383,6 +383,11 @@ EOT
       $browser->get($browser->response->header('Location'));
     }
 
+    if ($browser->response->code == 301) {
+      debug "Video not available (301), trying " . $browser->response->header('Location');
+      $browser->get($browser->response->header('Location'));
+    }
+
     if ($browser->response->code == 303) {
       debug "Video not available (303), trying " . $browser->response->header('Location');
       $browser->get($browser->response->header('Location'));


### PR DESCRIPTION
paczesiowa@desktop ~/projects/get-flash-videos $ ./get_flash_videos --debug www.youtube.com/watch?v=mGG6TlanJWs
1 plugin installed:
- Joemonster.pm
  Trying to open plugin ~/.get_flash_videos/plugins/Www.pm
  Trying to open plugin ~/.get_flash_videos/plugins/Youtube.pm
  Using method 'youtube' plugin version 0.01 for http://www.youtube.com/watch?v=mGG6TlanJWs
  Downloading http://www.youtube.com/watch?v=mGG6TlanJWs
  -> GET http://www.youtube.com/watch?v=mGG6TlanJWs
  <- 301 text/html; charset=utf-8 (0)
  Error: Couldn't download URL: 301 Moved Permanently at /home/paczesiowa/projects/get-flash-videos/lib/FlashVideo/Site/Youtube.pm line 392.

It works fine with this change.
