### PR TITLE
Fix the Arte plugin

### DIFF
--- a/lib/FlashVideo/Site/Arte.pm
+++ b/lib/FlashVideo/Site/Arte.pm
@@ -23,7 +23,7 @@ sub find_video {
     die "Unable to find language in original URL \"$pageurl\"\n";
   }
 
-  if($browser->content =~ /arte_vp_url="(.*)"/) {
+  if($browser->content =~ /arte_vp_url=['"](.*)['"]/) {
     $jsonurl = $1;
     debug "found arte_vp_url \"$jsonurl\"\n";
     ($filename = $jsonurl) =~ s/-.*$//;

--- a/lib/FlashVideo/Site/Arte.pm
+++ b/lib/FlashVideo/Site/Arte.pm
@@ -51,6 +51,10 @@ sub find_video {
     };
 
     return $videourl, $filename;
+  } elsif (defined ($result->{videoJsonPlayer}->{VSR}->{'HTTP_MP4_'.$quality.'_1'})) {
+    my $video_json = $result->{videoJsonPlayer}->{VSR}->{'HTTP_MP4_'.$quality.'_1'};
+
+    return $video_json->{url}, $filename;
   } elsif (defined ($result->{videoJsonPlayer}->{VSR}->{'HTTP_'.$quality.'_1'})) {
     my $video_json = $result->{videoJsonPlayer}->{VSR}->{'HTTP_'.$quality.'_1'};
     

--- a/lib/FlashVideo/Site/Arte.pm
+++ b/lib/FlashVideo/Site/Arte.pm
@@ -10,7 +10,7 @@ sub Version { $VERSION; }
 
 sub find_video {
   my ($self, $browser, $embed_url, $prefs) = @_;
-  my ($lang, $jsonurl, $filename, $videourl, $quality);
+  my ($lang, $jsonurl, $filename, $title, $videourl, $quality);
 
   debug "Arte::find_video called, embed_url = \"$embed_url\"\n";
 
@@ -27,9 +27,7 @@ sub find_video {
     $jsonurl = $1;
     debug "found arte_vp_url \"$jsonurl\"\n";
     ($filename = $jsonurl) =~ s/-.*$//;
-    $filename =~ s/^.*\///g;
-    $filename .= '_'.$prefs->{quality};
-    $filename = title_to_filename(extract_title($browser), 'flv');
+    $title = extract_title($browser);
   } else {
     die "Unable to find 'arte_vp_url' in page\n";
   }
@@ -43,6 +41,7 @@ sub find_video {
 
   if (defined ($result->{videoJsonPlayer}->{VSR}->{'RTMP_'.$quality.'_1'})) {
     my $video_json = $result->{videoJsonPlayer}->{VSR}->{'RTMP_'.$quality.'_1'};
+    $filename = title_to_filename($title, 'flv');
 
     $videourl = {
       rtmp     => $video_json->{streamer},
@@ -53,10 +52,12 @@ sub find_video {
     return $videourl, $filename;
   } elsif (defined ($result->{videoJsonPlayer}->{VSR}->{'HTTP_MP4_'.$quality.'_1'})) {
     my $video_json = $result->{videoJsonPlayer}->{VSR}->{'HTTP_MP4_'.$quality.'_1'};
+    $filename = title_to_filename($title, 'mp4');
 
     return $video_json->{url}, $filename;
   } elsif (defined ($result->{videoJsonPlayer}->{VSR}->{'HTTP_'.$quality.'_1'})) {
     my $video_json = $result->{videoJsonPlayer}->{VSR}->{'HTTP_'.$quality.'_1'};
+    $filename = title_to_filename($title, 'mp4');
 
     return $video_json->{url}, $filename;
   } else {

--- a/lib/FlashVideo/Site/Arte.pm
+++ b/lib/FlashVideo/Site/Arte.pm
@@ -43,8 +43,8 @@ sub find_video {
 
   if (defined ($result->{videoJsonPlayer}->{VSR}->{'RTMP_'.$quality.'_1'})) {
     my $video_json = $result->{videoJsonPlayer}->{VSR}->{'RTMP_'.$quality.'_1'};
-     
-    $videourl = { 
+
+    $videourl = {
       rtmp     => $video_json->{streamer},
       playpath => 'mp4:'.$video_json->{url},
       flv      => $filename,
@@ -57,12 +57,12 @@ sub find_video {
     return $video_json->{url}, $filename;
   } elsif (defined ($result->{videoJsonPlayer}->{VSR}->{'HTTP_'.$quality.'_1'})) {
     my $video_json = $result->{videoJsonPlayer}->{VSR}->{'HTTP_'.$quality.'_1'};
-    
+
     return $video_json->{url}, $filename;
   } else {
     die "Unable to figure out transport protocol in page\n";
   }
-    
+
 }
 
 1;


### PR DESCRIPTION
The Arte plugin was not working anymore because the `"` url string delimiter has been changed to `'`. Added the two delimiters to the regex to be sure.

Choose the downloaded file extension depending on the download method.

Added support for a new url type referenced in the json data: `HTTP_MP4_…`.