### PR TITLE
Fix issue #194

### DIFF
--- a/lib/FlashVideo/Site/Pbs.pm
+++ b/lib/FlashVideo/Site/Pbs.pm
@@ -203,6 +203,8 @@ EOT
 # Parse the json structure
   my $result = from_json($pbsdata);
   debug Data::Dumper::Dumper($result);
+  die "Could not extract video metadata.\n   Video may not be available.\n"
+     unless ref($result) eq "HASH";
   
   # Get the video's title and urs source
   my $title = $result->{title};

--- a/lib/FlashVideo/Utils.pm
+++ b/lib/FlashVideo/Utils.pm
@@ -561,7 +561,7 @@ sub read_hls_playlist {
 
   # Fill the url table
   foreach my $line (@lines) {
-    if ($line =~ /BANDWIDTH/) {
+    if ($line =~ /EXT-X-STREAM-INF/ && $line =~ /BANDWIDTH/) {
       $line =~ /BANDWIDTH=([0-9]*)/;
       $urltable{int($1)} = $lines[$i + 1];
     }


### PR DESCRIPTION
Fix for issue #194. filters out unwanted m3u8 entries.
Works fine on pbs.org site.