### PR TITLE
fix deprecation warning about unescaped left brace in regex

### DIFF
--- a/lib/FlashVideo/RTMPDownloader.pm
+++ b/lib/FlashVideo/RTMPDownloader.pm
@@ -219,7 +219,7 @@ sub run {
         $self->progress;
       } elsif(/\012$/) {
         for my $l(split /\012/) {
-          if($l =~ /^[A-F0-9]{,2}(?:\s+[A-F0-9]{2})*\s*$/) {
+          if($l =~ /^[A-F0-9]{0,2}(?:\s+[A-F0-9]{2})*\s*$/) {
             debug $l;
           } elsif($l =~ /Download complete/) {
             $complete = 1;


### PR DESCRIPTION

In Debian we are currently applying the following patch to
get-flash-videos.
We thought you might be interested in it too.

    Description: fix deprecation warning about unescaped left brace in regex
     $ perl -c lib/FlashVideo/RTMPDownloader.pm
     Unescaped left brace in regex is deprecated here (and will be fatal in Perl
     5.30), passed through in regex; marked by <-- HERE in m/^[A-F0-9]{ <-- HERE
     ,2}(?:\s+[A-F0-9]{2})*\s*$/ at lib/FlashVideo/RTMPDownloader.pm line 222.
     lib/FlashVideo/RTMPDownloader.pm syntax OK
    Author: Damyan Ivanov <dmn@debian.org>


The patch is tracked in our Git repository at
https://anonscm.debian.org/cgit/pkg-perl/packages/get-flash-videos.git/plain/debian/patches/deprecated-left-brace-in-regex.patch

Thanks for considering,
  Damyan Ivanov,
  Debian Perl Group
