### PR TITLE
Count https video URLs in the results

### DIFF
--- a/t/google_video_search.t
+++ b/t/google_video_search.t
@@ -23,7 +23,7 @@ my $sane_result_count = 0;
 foreach my $result (@results) {
   if ((ref($result) eq 'HASH') and
       $result->{name} and
-      $result->{url} =~ m'^http://') {
+      $result->{url} =~ m'^https?://') {
     $sane_result_count++;
   }
 }


### PR DESCRIPTION

In Debian we are currently applying the following patch to
get-flash-videos.
We thought you might be interested in it too.

    From ad36427136f759d3f7be85a074a4f8bafe5a42a9 Mon Sep 17 00:00:00 2001
    From: Niko Tyni <ntyni@debian.org>
    Date: Wed, 14 Oct 2015 10:06:31 +0300
    Subject: [PATCH] Count https video URLs in the results
    
    Some video URLs on the Google video site now start
    with https, making the test fail.

The patch is tracked in our Git repository at
https://anonscm.debian.org/cgit/pkg-perl/packages/get-flash-videos.git/plain/debian/patches/Count-https-video-URLs-in-the-results.patch

Thanks for considering,
  Damyan Ivanov,
  Debian Perl Group
